### PR TITLE
Fix error when using /bp clean

### DIFF
--- a/src/main/resources/assets/en_gb.bsk
+++ b/src/main/resources/assets/en_gb.bsk
@@ -6,3 +6,5 @@ function get(path):
       return "<info>Successfully unloaded <primary><script></primary> in <primary><time> ms</primary>!</info>"
     else if {path} is "commands.bytepaper.unload.not_loaded":
       return "<error>A script with that path isn't loaded!</error>"
+    else if {path} is "commands.bytepaper.clean.success":
+      return "<info>Successfully cleaning of compiled script directory in <primary><time> ms</primary>!</info>"


### PR DESCRIPTION
When the `/bg clean` command is executed, a **console error** is produced.
This is because a message with the path `commands.bytepaper.clean.success` is missing from the `en_gb.bsk` file

This PR aims to add this missing message