### PR TITLE
Folder scripts/ not created at startup

### DIFF
--- a/src/main/java/blue/lhf/bytepaper/BytePaper.java
+++ b/src/main/java/blue/lhf/bytepaper/BytePaper.java
@@ -76,6 +76,8 @@ public final class BytePaper extends JavaPlugin implements IScriptLoader {
             return;
         }
 
+        obtainScriptsFolder();
+
         if (!Exceptions.trying(getLogger(), Level.SEVERE, "loading the language script", (MayThrow.Runnable) () -> {
             Path langPath = obtainLanguageFolder().resolve("en_gb.bsk");
             if (Files.notExists(langPath)) {
@@ -143,7 +145,6 @@ public final class BytePaper extends JavaPlugin implements IScriptLoader {
             Exceptions.trying(Bukkit.getConsoleSender(), "creating the compiled scripts folder",
                 (MayThrow.Runnable) () -> Files.createDirectories(compiledFolder));
         }
-
 
         return compiledFolder;
     }


### PR DESCRIPTION
When the server starts, the `scripts/` folder is not created.
This folder is currently created only when the player tries to load a script that does not exist. 
So it should be created at startup to avoid the user having to create it by hand or via the command.

This PR aims to create the folder `scripts/` on startup
