### PR TITLE
Fix nulled command arguments when too many variable exists

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id("java-library")
     id("xyz.jpenilla.run-paper") version "1.0.6"
-    id("io.papermc.paperweight.userdev") version "1.3.7"
+    id("io.papermc.paperweight.userdev") version "1.5.5"
     id("com.github.johnrengelman.shadow") version "7.1.2"
     id("net.minecrell.plugin-yml.bukkit") version "0.5.2"
 }
@@ -44,7 +44,7 @@ java {
 
 dependencies {
     implementation 'org.reflections:reflections:0.10.2'
-    implementation "org.byteskript:byteskript:1.0.36"
+    implementation "org.byteskript:byteskript:1.0.39"
     paperweightDevelopmentBundle("io.papermc.paper:dev-bundle:${serverImpl}")
     implementation "com.moderocky:Commander:3.0.0-SNAPSHOT"
 }

--- a/src/main/java/blue/lhf/bytepaper/library/syntax/command/MemberCommand.java
+++ b/src/main/java/blue/lhf/bytepaper/library/syntax/command/MemberCommand.java
@@ -10,6 +10,7 @@ import org.byteskript.skript.compiler.structure.*;
 import org.byteskript.skript.lang.element.StandardElements;
 import org.objectweb.asm.Opcodes;
 
+import java.util.Arrays;
 import java.util.regex.Pattern;
 import java.util.regex.*;
 
@@ -88,6 +89,8 @@ public class MemberCommand extends TriggerHolder {
 
     @Override
     public Type[] parameters(Context context, Matcher match) {
+        Arrays.asList("__sender__", "__command__", "__label__", "__args__")
+                .forEach(v -> context.getVariable(v).parameter = true);
         return Type.of(CommandSender.class, Command.class, String.class, String[].class);
     }
 

--- a/src/main/java/blue/lhf/bytepaper/library/syntax/command/MemberCommand.java
+++ b/src/main/java/blue/lhf/bytepaper/library/syntax/command/MemberCommand.java
@@ -70,7 +70,7 @@ public class MemberCommand extends TriggerHolder {
                 load(new Type(Command.class), 1),
                 load(new Type(String.class), 2),
                 load(new Type(String[].class), 3),
-                invokeStatic(false, context.getType(), returnType(context, match), name, parameters(context, match)),
+                invokeStatic(false, context.getType(), returnType(context, match), name, parameters(context, match.matcher())),
                 push(true),
                 returnSmall()
             ).finish();
@@ -87,7 +87,7 @@ public class MemberCommand extends TriggerHolder {
     }
 
     @Override
-    public Type[] parameters(Context context, Match match) {
+    public Type[] parameters(Context context, Matcher match) {
         return Type.of(CommandSender.class, Command.class, String.class, String[].class);
     }
 

--- a/src/main/java/blue/lhf/bytepaper/library/syntax/entity/ExprEntities.java
+++ b/src/main/java/blue/lhf/bytepaper/library/syntax/entity/ExprEntities.java
@@ -1,8 +1,8 @@
 package blue.lhf.bytepaper.library.syntax.entity;
 
 import blue.lhf.bytepaper.util.Threading;
+import io.papermc.paper.util.MCUtil;
 import mx.kenzie.foundation.Type;
-import net.minecraft.server.MCUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;

--- a/src/main/java/blue/lhf/bytepaper/util/Threading.java
+++ b/src/main/java/blue/lhf/bytepaper/util/Threading.java
@@ -1,6 +1,6 @@
 package blue.lhf.bytepaper.util;
 
-import net.minecraft.server.MCUtil;
+import io.papermc.paper.util.MCUtil;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;


### PR DESCRIPTION
There's a bug when there are at least 2 new variables in a command section and there is a line of code accessing the command arguments. When that happens, the parameter holding command arguments is set to null and causing null pointer exception when accessed.

Here is an example.
```haskell
command /test:
    trigger:
        set {a} to 1
        set {b} to 2
        set {argLen} to size of args
        send {argLen} to executor
```

When compiled, it produced this. Notice `var3` is set to null.
```java
public static Void test(CommandSender var0, Command var1, String var2, String[] var3) {
    var1 = null;
    var2 = null;
    var3 = null;
    Integer var4 = 1;
    Integer var5 = 2;
    Object var6 = ExtractedSyntaxCalls.getListSize(Arrays.asList((Object[])var3));
    ((Audience)Skript.convert(var0, Audience.class)).sendMessage((Component)Skript.convert(var6, Component.class));
    return null;
}
```

Apparently this was caused by ByteSkript setting all non parameter and non internal variables to null. 

https://github.com/Moderocky/ByteSkript/blob/65ea545567a680bc0062572f48500d9e061e1b35/src/main/java/org/byteskript/skript/lang/syntax/entry/EntryTriggerSection.java#L64-L84

This PR aims to fix this by creating 4 parameter variables inside `parameters()` method, following [ByteSkript's MemberFunction.java](https://github.com/Moderocky/ByteSkript/blob/65ea545567a680bc0062572f48500d9e061e1b35/src/main/java/org/byteskript/skript/lang/syntax/function/MemberFunction.java#L129). If I compiled the above example using this fix, the output method didn't set the parameter variable to null. But `var4` somehow got skipped, I don't know why.

```java
public static Void test(CommandSender var0, Command var1, String var2, String[] var3) {
    Integer var5 = null;
    Integer var6 = null;
    Object var7 = null;
    var5 = 1;
    var6 = 2;
    var7 = ExtractedSyntaxCalls.getListSize(Arrays.asList((Object[])var3));
    ((Audience)Skript.convert(var0, Audience.class)).sendMessage((Component)Skript.convert(var7, Component.class));
    return null;
}
```

There are some changes that I needed to be able to build this plugin, i.e. [ExprEntities.java](https://github.com/bluelhf/BytePaper/compare/trunk...dirtboll:BytePaper:trunk#diff-3f16bd5759f5e1a272801e4e0d5a3abb7e01ebeb4cd9c9a868eec460ea829ccb) and [Threading.java](https://github.com/bluelhf/BytePaper/compare/trunk...dirtboll:BytePaper:trunk#diff-e3ce1c81d617f4504bbf58dd34288b71e67e4a36992e1918c6b417fdb6fa1196). I also upgraded ByteSkript and paperweight if you don't mind.
